### PR TITLE
Bumped Lychee version to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.4
+        uses: lycheeverse/lychee-action@v1.8.0
         with:
           args: "--verbose --no-progress './public/**/*.html'"
           fail: true


### PR DESCRIPTION
The link checker is failing for a long time, so I increased the version number to the latest. This is one attempt to fix it, hopefully we don't have to put that link into the ignored list.