### PR TITLE
Keep background image static when event boxes open or close

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,6 +9,7 @@
 
     html {
       font-size: 1.1em;
+      scrollbar-gutter: stable;
     }
 
     body {
@@ -18,6 +19,7 @@
       line-height: 1.5;
       background-image: url(/graphics/stars_background.png);
       background-position: center;
+      background-attachment: fixed;
       -webkit-font-smoothing: antialiased;
       -moz-font-smoothing: antialiased;
       -o-font-smoothing: antialiased;


### PR DESCRIPTION
Anchor the body background to the viewport and reserve scrollbar space so page-height changes no longer shift the stars image.